### PR TITLE
Fixed target check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ $(eval $(if $(TARGET_MASTER),TARGET_CONFIGS=$(TARGET_MASTER),TARGET_CONFIGS=$(T)
 $(eval $(if $(TARGET),,TARGET=$(T)))
 
 #Define BUILD_PATH based on TBUILD (defined in targets.mk)
-$(eval $(if $(TBUILD),,TBUILD=$(TARGET)))
 BUILD_PATH=$(BUILD_DIR)/$(TBUILD)
 
 #Getting output image paths


### PR DESCRIPTION
Hi, lime-build didn't stops the user when a non existent target is used, as reported here:
https://github.com/libre-mesh/lime-build/issues/1
This fixes.
