### PR TITLE
Added CONFIG_TARGET specification for LiMe targets

### DIFF
--- a/configs/targets/bullet
+++ b/configs/targets/bullet
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_UBNT=y

--- a/configs/targets/dragino2
+++ b/configs/targets/dragino2
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_DRAGINO2=y

--- a/configs/targets/nsm2
+++ b/configs/targets/nsm2
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_UBNT=y

--- a/configs/targets/nsm5
+++ b/configs/targets/nsm5
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_UBNT=y

--- a/configs/targets/rocket
+++ b/configs/targets/rocket
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_UBNT=y

--- a/configs/targets/rs
+++ b/configs/targets/rs
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_UBNTRS=y

--- a/configs/targets/rspro
+++ b/configs/targets/rspro
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_UBNTRSPRO=y

--- a/configs/targets/tl-2543
+++ b/configs/targets/tl-2543
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWR2543=y

--- a/configs/targets/tl-703n
+++ b/configs/targets/tl-703n
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWR703=y

--- a/configs/targets/tl-841
+++ b/configs/targets/tl-841
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWR841=y

--- a/configs/targets/tl-842
+++ b/configs/targets/tl-842
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWR842=y

--- a/configs/targets/tl-mr3020
+++ b/configs/targets/tl-mr3020
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLMR3020=y

--- a/configs/targets/tl-mr3040
+++ b/configs/targets/tl-mr3040
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLMR3040=y

--- a/configs/targets/tl-mr3040-cam
+++ b/configs/targets/tl-mr3040-cam
@@ -6,4 +6,4 @@ CONFIG_PACKAGE_kmod-video-videobuf2=y
 CONFIG_PACKAGE_libjpeg=y
 CONFIG_PACKAGE_libpthread=y
 CONFIG_PACKAGE_mjpg-streamer=y
-
+CONFIG_TARGET_ar71xx_generic_TLMR3040=y

--- a/configs/targets/tl-wdr3500
+++ b/configs/targets/tl-wdr3500
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWDR4300=y

--- a/configs/targets/tl-wdr3600
+++ b/configs/targets/tl-wdr3600
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWDR4300=y

--- a/configs/targets/tl-wdr4300
+++ b/configs/targets/tl-wdr4300
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWDR4300=y

--- a/configs/targets/tl-wr841n-v7
+++ b/configs/targets/tl-wr841n-v7
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWR841=y

--- a/configs/targets/tl-wr841n-v8
+++ b/configs/targets/tl-wr841n-v8
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWR841=y

--- a/configs/targets/tl-wr841n-v9
+++ b/configs/targets/tl-wr841n-v9
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_TLWR841=y

--- a/configs/targets/wpe72
+++ b/configs/targets/wpe72
@@ -1,0 +1,1 @@
+CONFIG_TARGET_ar71xx_generic_WPE72=y


### PR DESCRIPTION
For reducing the needed disk space and compilation time I added the specification of CONFIG_TARGET by OpenWrt in each Libre-Mesh target.
