### PR TITLE
Separate manually set packages from profile ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ define checkout_src
 endef
 
 define add_profile_packages
-	@echo "Adding profile packages: $(PACKAGES)"
-	@for PKG in $(PACKAGES); do echo "CONFIG_PACKAGE_$$PKG=y" >> $(CONFIG); done
+	@echo "Adding profile packages: $(PROFILE_PACKAGES) $(PACKAGES)"
+	@for PKG in $(PROFILE_PACKAGES) $(PACKAGES); do echo "CONFIG_PACKAGE_$$PKG=y" >> $(CONFIG); done
 endef
 
 define copy_config

--- a/profiles.mk
+++ b/profiles.mk
@@ -1,5 +1,5 @@
 # profiles.mk
-PROFILES_AVAILABLE:=generic freifunk chef
+PROFILES_AVAILABLE:=generic freifunk chef custom
 
 ifeq ($(P),generic)
   PROFILE_PACKAGES:=lime-full
@@ -11,4 +11,8 @@ endif
 
 ifeq ($(P),chef)
   PROFILE_PACKAGES:=lime-full lime-freifunk
+endif
+
+ifeq ($(P),custom)
+  PROFILE_PACKAGES:=
 endif

--- a/profiles.mk
+++ b/profiles.mk
@@ -2,13 +2,13 @@
 PROFILES_AVAILABLE:=generic freifunk chef
 
 ifeq ($(P),generic)
-  PACKAGES:=lime-full
+  PROFILE_PACKAGES:=lime-full
 endif
 
 ifeq ($(P),freifunk)
-  PACKAGES:=lime-freifunk
+  PROFILE_PACKAGES:=lime-freifunk
 endif
 
 ifeq ($(P),chef)
-  PACKAGES:=lime-full lime-freifunk
+  PROFILE_PACKAGES:=lime-full lime-freifunk
 endif


### PR DESCRIPTION
If a package is indicated in the make command, the ones from the profile gets ignored, so

`make T=ar71xx P=generic J=3 PACKAGES="lime-hwd-ground-routing"`

results in the profile packages being ignored:

```
grep lime build/src/.config
CONFIG_FEED_lime_packages=y
# CONFIG_PACKAGE_luci-mod-lime-basic is not set
# CONFIG_PACKAGE_luci-mod-lime-basic-ssl is not set
# CONFIG_PACKAGE_lime-altermesh is not set
# CONFIG_PACKAGE_lime-debug is not set
# CONFIG_PACKAGE_lime-eb-ip-tables is not set
# CONFIG_PACKAGE_lime-freifunk is not set
# CONFIG_PACKAGE_lime-full is not set
CONFIG_PACKAGE_lime-hwd-ground-routing=y
# CONFIG_PACKAGE_lime-hwd-openwrt-wan is not set
# CONFIG_PACKAGE_lime-hwd-usbradio is not set
# CONFIG_PACKAGE_lime-map-agent is not set
# CONFIG_PACKAGE_lime-proto-anygw is not set
# CONFIG_PACKAGE_lime-proto-batadv is not set
# CONFIG_PACKAGE_lime-proto-bgp is not set
# CONFIG_PACKAGE_lime-proto-bmx6 is not set
# CONFIG_PACKAGE_lime-proto-eigennet is not set
# CONFIG_PACKAGE_lime-proto-olsr is not set
# CONFIG_PACKAGE_lime-proto-olsr2 is not set
# CONFIG_PACKAGE_lime-proto-olsr6 is not set
# CONFIG_PACKAGE_lime-proto-qmp is not set
# CONFIG_PACKAGE_lime-proto-wan is not set
CONFIG_PACKAGE_lime-system=y
# CONFIG_PACKAGE_lime-webui is not set
# CONFIG_PACKAGE_luci-app-lime-location is not set
```

I also added a "void" profile for specifying manually all the needed packages.
