### PR TITLE
Fix targets.mk and target file for mt7620

### DIFF
--- a/targets.mk
+++ b/targets.mk
@@ -23,12 +23,10 @@ endif
 
 ifeq ($(T),mt7620)
   ARCH:=ramips
-  OUTDIR:=bin/targets/$(ARCH)/generic
+  OUTDIR:=bin/targets/$(ARCH)/mt7620
 endif
 
 ifeq ($(T),mt7621)
   ARCH:=ramips
   OUTDIR:=bin/targets/$(ARCH)/mt7621
 endif
-
-

--- a/targets/mt7620
+++ b/targets/mt7620
@@ -1,6 +1,6 @@
 CONFIG_TARGET_ramips=y
-CONFIG_TARGET_ramips_mt7620n=y
-CONFIG_TARGET_ramips_mt7620n_Default=y
+CONFIG_TARGET_ramips_mt7620=y
+CONFIG_TARGET_ramips_mt7620_Default=y
 CONFIG_PACKAGE_dnsmasq=n
 CONFIG_PACKAGE_dnsmasq-dhcpv6=y
 CONFIG_PACKAGE_ppp=n


### PR DESCRIPTION
The name changed from `mt7620n` to `mt7620` in OpenWrt CC and in LEDE is already like this.

The dir for compiled images is not the `generic`, but is the `mt7620` (don't know if this is a bug itself).