### PR TITLE
Re-add bmx7olsr1 to PROFILES_AVAILABLE which got removed in f92c2d5

### DIFF
--- a/profiles.mk
+++ b/profiles.mk
@@ -1,5 +1,5 @@
 # profiles.mk
-PROFILES_AVAILABLE:=generic basic freifunk chef ui-ng-test custom
+PROFILES_AVAILABLE:=generic basic freifunk chef ui-ng-test custom bmx7olsr1
 
 ifeq ($(P),generic)
   PROFILE_PACKAGES:=lime-full


### PR DESCRIPTION
In f92c2d5 the bmx7olsr1 entry was removed from PROFILES_AVAILABLE in profiles.mk but the relative section in the same file was not.
Also removing the bmx7olsr1 section from profiles.mk would solve.