### PR TITLE
Replace non existing routing repo feed with LEDE one

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -2,7 +2,7 @@
 src-link lime_packages PATH/lime-packages/packages
 src-git packages https://git.lede-project.org/feed/packages.git;lede-17.01
 src-git luci https://git.lede-project.org/project/luci.git;lede-17.01
-src-git routing https://git.lede-project.org/feed/routing.git;lede-17.01
+src-git routing https://git.lede-project.org/feed/routing.git
 src-git telephony https://git.lede-project.org/feed/telephony.git;lede-17.01
 src-git lime_ui_ng https://github.com/libremesh/lime-ui-ng.git
 src-git libremap_agent https://github.com/libremap/libremap-agent-openwrt.git

--- a/feeds.conf
+++ b/feeds.conf
@@ -2,7 +2,7 @@
 src-link lime_packages PATH/lime-packages/packages
 src-git packages https://git.lede-project.org/feed/packages.git;lede-17.01
 src-git luci https://git.lede-project.org/project/luci.git;lede-17.01
-src-git routing https://github.com/p4u/openwrt-routing.git;lede-17.01
+src-git routing https://git.lede-project.org/feed/routing.git;lede-17.01
 src-git telephony https://git.lede-project.org/feed/telephony.git;lede-17.01
 src-git lime_ui_ng https://github.com/libremesh/lime-ui-ng.git
 src-git libremap_agent https://github.com/libremap/libremap-agent-openwrt.git


### PR DESCRIPTION
A @p4u's repo was included in feeds.conf file and then eliminated.